### PR TITLE
Ability to filter entries by hash tags.

### DIFF
--- a/dayone_export.py
+++ b/dayone_export.py
@@ -44,13 +44,12 @@ The module also makes the timezone function from pytz available.
 """
 
 from jinja2 import Environment, FileSystemLoader
-from pytz import timezone, utc, UnknownTimeZoneError
 from operator import itemgetter
 import plistlib
-import datetime
 import codecs
 import sys
 import os
+import times
 
 SUBKEYS = {'Location': ['Locality', 'Country', 'Place Name',
                  'Administrative Area', 'Longitude', 'Latitude'],
@@ -76,7 +75,7 @@ class Entry(object):
     data.
     """
 
-    def __init__(self, filename, timezone=utc):
+    def __init__(self, filename):
         try:
             self.data = plistlib.readPlist(filename)
         except Exception as err:
@@ -86,8 +85,6 @@ class Entry(object):
             raise KeyError("{} is missing Creation Date".format(filename))
         if "Entry Text" not in self.data:
             raise KeyError("{} is missing Entry Text".format(filename))
-        self.data['Creation Date'] = utc.localize(
-            self.data['Creation Date']).astimezone(timezone)
 
     def add_photo(self, filename):
         self.data['Photo'] = filename
@@ -177,14 +174,13 @@ class Entry(object):
         return "<Entry at {}>".format(self['Date'].strftime(
           "%Y-%m-%dT%H:%M:%S%z"))
 
-def parse_journal(foldername, timezone=utc, reverse=False):
+def parse_journal(foldername, reverse=False):
     """Return a list of Entry objects, sorted by date"""
 
     journal = dict()
     for filename in os.listdir(os.path.join(foldername, 'entries')):
         if os.path.splitext(filename)[1] == '.doentry':
-            entry = Entry(os.path.join(foldername, 'entries', filename),
-              timezone=timezone)
+            entry = Entry(os.path.join(foldername, 'entries', filename))
             journal[entry['UUID']] = entry
 
     if len(journal) == 0:
@@ -208,8 +204,8 @@ def parse_journal(foldername, timezone=utc, reverse=False):
     journal.sort(key=itemgetter('Creation Date'), reverse=reverse)
     return journal
 
-def dayone_export(dayone_folder, template="template.html", timezone=utc,
-  reverse=False):
+def dayone_export(dayone_folder, template="template.html", timezone='utc',
+  reverse=False, after=None):
     """Combines dayone data using the template"""
 
     #setup jinja2
@@ -237,12 +233,16 @@ def dayone_export(dayone_folder, template="template.html", timezone=utc,
     template = env.get_template(base)
 
     # parse journal
-    j = parse_journal(dayone_folder, timezone=timezone, reverse=reverse)
+    j = parse_journal(dayone_folder, reverse=reverse)
+
+    if after is not None:
+        after = times.to_universal(after, timezone=timezone)
+        j = [item for item in j if item['Date'] > after]
 
     # may throw an exception if the template is malformed
     # the traceback is helpful, so i'm letting it through
     # it might be nice to clean up the error message, someday
-    return template.render(journal=j)
+    return template.render(journal=j, timezone=timezone, times=times)
 
 def parse_args():
     """Parse command line arguments"""
@@ -250,7 +250,7 @@ def parse_args():
     parser = argparse.ArgumentParser(
       description="Export Day One entries using a Jinja template",
       usage="""%(prog)s [-h] [--template FILE] [--output FILE]
-                 [--timezone ZONE] [--reverse] journal""",
+                 [--timezone ZONE] [--after DATETIME] [--reverse] journal""",
       epilog="""Photos are not copied from the Day One package.
         If it has photos you will need to copy the "photos" folder from
         inside the Day One package into the same directory as the output file.
@@ -260,6 +260,8 @@ def parse_args():
     parser.add_argument('--output', metavar="FILE", help="output file")
     parser.add_argument('--timezone', metavar="ZONE",
       help='time zone name. Use --timezone "?" for more info')
+    parser.add_argument('--after',
+      help='export entries published after this date')
     parser.add_argument('--reverse', action="store_true",
       help="Display in reverse chronological order")
     parser.add_argument('journal', help="path to Day One journal package",
@@ -310,13 +312,13 @@ if __name__ == "__main__":
         args.output = "journal" + ("-output" if base == "journal" else "") + ext
 
     if args.timezone is None or len(args.timezone) == 0:
-        tz = utc
+        tz = 'utc'
     elif args.timezone[0] == "?":
         timezone_help(args.timezone)
     else:
         try:
-            tz = timezone(args.timezone)
-        except UnknownTimeZoneError:
+            tz = times.pytz.timezone(args.timezone)
+        except times.pytz.UnknownTimeZoneError:
             sys.exit("Unknown time zone: " + args.timezone)
 
     # Make sure there is a journal
@@ -335,7 +337,7 @@ if __name__ == "__main__":
 
     try:
         output = dayone_export(args.journal, template=args.template,
-          timezone=tz, reverse=args.reverse)
+          timezone=tz, reverse=args.reverse, after=args.after)
     except IOError as err:
         sys.exit(err)
 

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,9 @@ Adjust the argument to be the path to your Day One journal.
       --template FILE  template file
       --output FILE    output file
       --after DATETIME export only entries after the date
+      --tags TAGS      export entries with these comma-separated tags.
+                       Tag 'any' has a special meaning, it says to export
+                       entries with one or more tags.
       --timezone ZONE  time zone name. Use --timezone "?" for more info
       --reverse        Display in reverse chronological order
 

--- a/readme.md
+++ b/readme.md
@@ -6,12 +6,12 @@ by Nathan Grigg
 # Requirements
 
 - [jinja2][1] for templating
-- [pytz][2] for time zone support.
+- [times][2] for time zone support.
 - [markdown][3] (optional) to convert entries to html.
 
 If you have [pip][4] installed, you can run
 
-    pip install jinja2 pytz markdown
+    pip install jinja2 times markdown
 
 and you are ready to go.
 
@@ -38,6 +38,7 @@ Adjust the argument to be the path to your Day One journal.
       -h, --help       show this help message and exit
       --template FILE  template file
       --output FILE    output file
+      --after DATETIME export only entries after the date
       --timezone ZONE  time zone name. Use --timezone "?" for more info
       --reverse        Display in reverse chronological order
 
@@ -52,7 +53,7 @@ Adjust the argument to be the path to your Day One journal.
     Journal Entries
     ===============
     {% for entry in journal %}
-    Date: {{ entry['Date'].strftime('%A, %b %e, %Y') }}
+    Date: {{ times.format(entry['Date'], timezone, '%A, %b %e, %Y') }}
 
     {{ entry['Text'] }}
 
@@ -111,9 +112,11 @@ see the code.
 
 ## Dates
 
-You can call Python's `strftime` on the date to format it. For example:
+You can call `times.format` on the date to format it from internal UTC into
+desired timezone. A `timezone` context variable refers to a timezone, specified
+with `--timezone` option, which is `UTC` by default. For example:
 
-    {{ entry['Date'].strftime('%Y-%m-%d %H:%M:%S %z') }}
+    {{ times.format(entry['Date'], timezone, '%Y-%m-%d %H:%M:%S %z') }}
 
 ## The markdown filter
 
@@ -131,7 +134,7 @@ For more details on Jinja templates, see the
 
 [0]: http://dayoneapp.com
 [1]: http://jinja.pocoo.org
-[2]: http://pytz.sourceforge.net
+[2]: http://pypi.python.org/pypi/times/
 [3]: http://freewisdom.org/projects/python-markdown/
 [4]: http://www.pip-installer.org/en/latest/index.html
 [5]: http://jinja.pocoo.org/docs/templates/

--- a/template.html
+++ b/template.html
@@ -9,12 +9,12 @@
 <h1 class="page-title">Journal Entries</h1>
 {% for entry in journal %}
 <article class="entry">
-    <h1 class="entry-title">{{ entry['Date'].strftime('%A, %b %e, %Y') }}</h1>
+    <h1 class="entry-title">{{ times.format(entry['Date'], timezone, '%A, %b %e, %Y') }}</h1>
     <p class="location time">
         {% if 'Location' in entry %}
         {{ entry.place(ignore="United States") }},
         {% endif %}
-        {{ entry['Date'].strftime("%-I:%M %p %Z") }}
+        {{ times.format(entry['Date'], timezone, '%-I:%M %p %Z') }}
     </p>
     <div class="entry-text">
         {% if 'Photo' in entry %}

--- a/template.md
+++ b/template.md
@@ -1,0 +1,6 @@
+{% for entry in journal %}
+{{ times.format(entry['Date'], timezone, '%A, %b %e, %Y') }}
+--------------------------
+* {{ entry['Text'] }}
+
+{% endfor %}


### PR DESCRIPTION
A new option `--tags` was added to filter by tags.
Usually, it is a comma-separated tags, but this
option have one special value `any` which says
to export only entries with tags.

Tags are extracted from the end of the texts. They are
a words starting from the `#` letter.
