### PR TITLE
Ability to filter entries by hash tags.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,9 @@ Adjust the argument to be the path to your Day One journal.
       -h, --help       show this help message and exit
       --template FILE  template file
       --output FILE    output file
+      --tags TAGS      export entries with these comma-separated tags.
+                       Tag 'any' has a special meaning, it says to export
+                       entries with one or more tags.
       --timezone ZONE  time zone name. Use --timezone "?" for more info
       --reverse        Display in reverse chronological order
 


### PR DESCRIPTION
A new option --tags was added to filter by tags.
Usually, it is a comma-separated tags, but this
option have one special value 'any' which says
to export only entries with tags.

Tags are extracted from the end of the texts. They are
a words starting from the # letter.
