### PR TITLE
Added weather method to entry object

### DIFF
--- a/dayone_export/__init__.py
+++ b/dayone_export/__init__.py
@@ -127,6 +127,18 @@ class Entry(object):
             raise TypeError("'ignore' argument must be a string or list")
 
         return ", ".join(names)
+        
+    def weather(self, temperature_type):
+        if not 'Weather' in self:
+            return "" # fail silently
+        
+        if temperature_type.lower() == 'celsius' or temperature_type.lower() == 'c':
+            temperature = self.data['Celsius']
+        else:
+            temperature = self.data['Fahrenheit']
+        
+        weather = "{0}&deg; {1}".format(temperature, self.data['Description'])
+        return weather
 
     def __getitem__(self, key):
         return self.data[key]

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -103,6 +103,22 @@ inside double braces.
 More information is available in the documentation for :ref:`Entry`.
 
 
+Weather
+------
+
+You may want to combine the weather into a single string.
+You can do this with the ``weather`` method.
+
+The ``weather`` method takes one parameter to display the temperature as celcius
+or fahrenheit. For example, ``entry.weather('F')`` will display the temperature
+in fahrenheit. The same can be done for celsius but with ``entry.weather('C')``.
+ 
+Don't forget that to insert any of this into the document, you need to put it
+inside double braces.
+
+More information is available in the documentation for :ref:`Entry`.
+
+
 Jinja Filters
 -------------
 


### PR DESCRIPTION
I added a `weather` method to the entry object. The `weather` method simply prints out the temperature and weather description. The `weather` method takes one parameter, `'c'` if you want Celsius and `'f'` if you want Fahrenheit. Though all this information is accessible through the entry dictionary, I thought it would be useful to print it out in one string (much like location).

I ran the tests and everything passed.
