### PR TITLE
Multiple-file output

### DIFF
--- a/dayone_export/__init__.py
+++ b/dayone_export/__init__.py
@@ -15,6 +15,7 @@ import plistlib
 import os
 import pytz
 import itertools
+from collections import defaultdict
 
 SUBKEYS = {'Location': ['Locality', 'Country', 'Place Name',
                  'Administrative Area', 'Longitude', 'Latitude'],
@@ -350,6 +351,10 @@ def dayone_export(dayone_folder, template=None, reverse=False, tags=None,
     # The traceback is helpful, so I'm letting it through
     # it might be nice to clean up the error message, someday
 
-    for k, g in itertools.groupby(j, lambda e: e['Date'].strftime(filename_template)):
-        yield k, template.render(journal=list(g))
+    output_groups = defaultdict(list)
+    for e in j:
+        output_groups[e['Date'].strftime(filename_template)].append(e)
+
+    for k in output_groups:
+        yield k, template.render(journal=output_groups[k])
 

--- a/dayone_export/__init__.py
+++ b/dayone_export/__init__.py
@@ -258,7 +258,7 @@ def _filter_by_after_date(journal, date):
 
 def dayone_export(dayone_folder, template=None, reverse=False, tags=None,
     after=None, format=None, template_dir=None, autobold=False, nl2br=False,
-    time_grouper=""):
+    filename_template=""):
     """Render a template using entries from a Day One journal.
 
     :param dayone_folder: Name of Day One folder; generally ends in ``.dayone``.
@@ -290,11 +290,11 @@ def dayone_export(dayone_folder, template=None, reverse=False, tags=None,
     :type autobold: bool
     :param nl2br:  Specifies that new lines should be translated in to <br>s
     :type nl2br: bool
-    :type time_grouper: string
-    :param time_grouper: Time strftime format. 
-                When it changes, new template is created. 
-                If specified, function becomes an interator returning the next template.
-    :returns: Filled in template as string.
+    :type filename_template: string
+    :param filename_template: An eventual filename, which can include strftime formatting codes. 
+                Each time the result of formatting an entry's timestamp with this changes,
+                a new result will be returned.              
+    :returns: Iterator yielding (filename, filled_in_template) as strings on each iteration.
     """
 
     # figure out which template to use
@@ -342,14 +342,14 @@ def dayone_export(dayone_folder, template=None, reverse=False, tags=None,
 
 
     # Split into groups, possibly of length one
-    # Generate a new output for each time the 'time_grouper' changes.
-    # Yield the resulting time_grouper plus the output.
-    # If the time_grouper is an empty string (the default), we'll get
+    # Generate a new output for each time the 'filename_template' changes.
+    # Yield the resulting filename_template plus the output.
+    # If the filename_template is an empty string (the default), we'll get
     # an empty grouper plus the rendering of the full list of entries.
     # This may throw an exception if the template is malformed.
     # The traceback is helpful, so I'm letting it through
     # it might be nice to clean up the error message, someday
 
-    for k, g in itertools.groupby(j, lambda e: e['Date'].strftime(time_grouper)):
+    for k, g in itertools.groupby(j, lambda e: e['Date'].strftime(filename_template)):
         yield k, template.render(journal=list(g))
 

--- a/dayone_export/cli.py
+++ b/dayone_export/cli.py
@@ -40,8 +40,6 @@ def parse_args(args=None):
       help="autobold first lines (titles) of posts")
     parser.add_argument('--nl2br', action="store_true",
       help="convert each new line to a <br>")
-    parser.add_argument('--time-group', metavar="FMT", default="",
-      help="create new file each time this strftime-format suffix changes")
 
     parser.add_argument('--version', action='version', version=VERSION)
     return parser.parse_args(args)
@@ -88,16 +86,16 @@ def run(args=None):
         generator = dayone_export(args.journal, template=args.template,
           reverse=args.reverse, tags=tags, after=args.after,
           format=args.format, template_dir=args.template_dir,
-          autobold=args.autobold, nl2br=args.nl2br, time_grouper=args.time_group)
+          autobold=args.autobold, nl2br=args.nl2br, filename_template=args.output)
     except jinja2.TemplateNotFound as err:
         return "Template not found: {0}".format(err)
 
     try:
         
-        # Output is a generator returning each file's name suffix and contents one at a time
-        for suffix, output in generator:
+        # Output is a generator returning each file's name and contents one at a time
+        for filename, output in generator:
             if args.output:
-                with codecs.open(args.output + suffix, 'w', encoding='utf-8') as f:
+                with codecs.open(filename, 'w', encoding='utf-8') as f:
                     f.write(output)
             else:
                 print_bytes(output.encode('utf-8'))

--- a/dayone_export/cli.py
+++ b/dayone_export/cli.py
@@ -40,6 +40,9 @@ def parse_args(args=None):
       help="autobold first lines (titles) of posts")
     parser.add_argument('--nl2br', action="store_true",
       help="convert each new line to a <br>")
+    parser.add_argument('--time-group', metavar="FMT", default="",
+      help="create new file each time this strftime-format suffix changes")
+
     parser.add_argument('--version', action='version', version=VERSION)
     return parser.parse_args(args)
 
@@ -82,22 +85,26 @@ def run(args=None):
             return "Unable to parse date '{0}'".format(args.after)
 
     try:
-        output = dayone_export(args.journal, template=args.template,
+        generator = dayone_export(args.journal, template=args.template,
           reverse=args.reverse, tags=tags, after=args.after,
           format=args.format, template_dir=args.template_dir,
-          autobold=args.autobold, nl2br=args.nl2br)
+          autobold=args.autobold, nl2br=args.nl2br, time_grouper=args.time_group)
     except jinja2.TemplateNotFound as err:
         return "Template not found: {0}".format(err)
 
-    if args.output:
-        try:
-            with codecs.open(args.output, 'w', encoding='utf-8') as f:
-                f.write(output)
-        except IOError as err:
-            return str(err)
-    else:
-        print_bytes(output.encode('utf-8'))
-        print_bytes("\n".encode('utf-8'))
+    try:
+        
+        # Output is a generator returning each file's name suffix and contents one at a time
+        for suffix, output in generator:
+            if args.output:
+                with codecs.open(args.output + suffix, 'w', encoding='utf-8') as f:
+                    f.write(output)
+            else:
+                print_bytes(output.encode('utf-8'))
+                print_bytes("\n".encode('utf-8'))
+
+    except IOError as err:
+        return str(err)
 
 
 if __name__ == "__main__":

--- a/dayone_export/cli.py
+++ b/dayone_export/cli.py
@@ -23,7 +23,7 @@ def parse_args(args=None):
         as the output file.""")
     parser.add_argument('journal', help="path to Day One journal package")
     parser.add_argument('--output', metavar="FILE",
-      help="file to write (default print to stdout)")
+      help="file to write, or filename template (default print to stdout)")
     parser.add_argument('--format', metavar="FMT",
       help="output format (default guess from output file extension)")
     parser.add_argument('--template', metavar="NAME",

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -18,7 +18,7 @@ Basic Usage
 
     optional arguments:
       -h, --help          show this help message and exit
-      --output FILE       file to write (default print to stdout)
+      --output FILE       file to write (default print to stdout) or filename template
       --format FMT        output format (default guess from output file extension)
       --template NAME     name or file of template to use
       --template-dir DIR  location of templates (default ~/.dayone_export)
@@ -93,4 +93,22 @@ as the output html file.
 There is an alternate template which embeds photos directly into the html
 file as base64-encoded images. To use this template, use the option
 ``--template imgbase64.html``.
+
+Template filenames and grouping
+-------------------------------
+
+The ``--output`` option specifies the output filename if you
+want something other than stdout.  
+
+It also has another feature: you can include strftime-style formatting codes,
+in which case multiple files will be produced, each containing the journal entries 
+with timestamps that result in the same filename.
+
+Examples:
+
+  ``--output journal_%Y_%m.md`` will produces monthly files named journal_2013_02.md etc.
+
+  ``--output diary_%a.html`` will produce a separate file for each weekday.
+
+
 

--- a/tests/test_dayone_export.py
+++ b/tests/test_dayone_export.py
@@ -299,6 +299,6 @@ class TestLatex(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_latex_sanity(self):
-        suffix, actual = doe.dayone_export(fake_journal, format='tex').next()
+        suffix, actual = next(doe.dayone_export(fake_journal, format='tex'))
         expected = r'\documentclass'
         self.assertEqual(actual[:14], expected)

--- a/tests/test_dayone_export.py
+++ b/tests/test_dayone_export.py
@@ -299,6 +299,6 @@ class TestLatex(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_latex_sanity(self):
-        actual = doe.dayone_export(fake_journal, format='tex')
+        suffix, actual = doe.dayone_export(fake_journal, format='tex').next()
         expected = r'\documentclass'
         self.assertEqual(actual[:14], expected)

--- a/tests/test_dayone_export.py
+++ b/tests/test_dayone_export.py
@@ -122,6 +122,18 @@ class TestJournalParser(unittest.TestCase):
         filtered = doe._filter_by_tag(self.j, ['porcupine'])
         self.assertEqual(len(filtered), 0)
 
+    @patch('jinja2.Template.render')
+    def test_file_splitter(self, mock_render):
+        gen = doe.dayone_export(fake_journal)
+        self.assertEqual(len(list(gen)), 1)
+        # If doing careful date comparisons, beware of timezones
+        gen = doe.dayone_export(fake_journal, filename_template="j_%Y.md")
+        self.assertEqual(len(list(gen)), 2)
+        gen = doe.dayone_export(fake_journal, filename_template="j_%Y%_%m_%d.md")
+        self.assertEqual(len(list(gen)), 3)
+
+
+
 class TestTemplateInheritance(unittest.TestCase):
     def setUp(self):
         self.patcher1 = patch('jinja2.ChoiceLoader', side_effect=lambda x:x)
@@ -215,6 +227,7 @@ class TestCLI(unittest.TestCase):
         expected = "Template not found"
         self.assertTrue(actual.startswith(expected), actual)
 
+
 class TestMarkdown(unittest.TestCase):
     """Test the markdown formatter"""
     def setUp(self):
@@ -302,3 +315,4 @@ class TestLatex(unittest.TestCase):
         suffix, actual = next(doe.dayone_export(fake_journal, format='tex'))
         expected = r'\documentclass'
         self.assertEqual(actual[:14], expected)
+


### PR DESCRIPTION
Hi Nathan - 

I've made a small change to your excellent dayone_export for my own particular needs.  Feel free to pull it if you think it might be useful for others, or reject it if not - I won't be offended!

I wanted to be able to create multiple output files split up by date rather than just a single monolithic one; in my case, I'll probably have them named something like journal_2013_03.md.  

So this patch adds the --time-group parameter which takes a strftime-style string to format the timestamp, and creates a new output file with this as a suffix whenever the result changes.

e.g.

`dayone_export --output journal --time-group "_%Y_%m.md" --format md  Journal.dayone`

I've changed the dayone_export() function so that, rather than just returning the text, it returns a generator giving (suffix, text) each time the suffix changes.  That's perhaps a slightly eccentric way of doing it but it seems to work OK, and I couldn't think of an alternative involving so few line changes from your original!

If you like this approach and want to include it I can update the docs too, if that would be helpful.

All the best, and many thanks,
Quentin
